### PR TITLE
Phase 8: QA-Findings & Clippy Clean

### DIFF
--- a/flux-ftl/src/ast.rs
+++ b/flux-ftl/src/ast.rs
@@ -55,18 +55,13 @@ pub enum Literal {
 // Layout — memory layout strategy for struct types
 // ---------------------------------------------------------------------------
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Layout {
+    #[default]
     Optimal,
     Packed,
     CAbi,
-}
-
-impl Default for Layout {
-    fn default() -> Self {
-        Self::Optimal
-    }
 }
 
 // ---------------------------------------------------------------------------

--- a/flux-ftl/src/codegen.rs
+++ b/flux-ftl/src/codegen.rs
@@ -441,11 +441,11 @@ impl<'ctx, 'prog> CodeGenerator<'ctx, 'prog> {
 
         // If the builder's current block has no terminator, add `ret i32 0`
         let current_block = builder.get_insert_block();
-        if let Some(block) = current_block {
-            if block.get_terminator().is_none() {
-                builder.build_return(Some(&i32_type.const_int(0, false)))
-                    .map_err(|e| CodegenError::EmitFailed(e.to_string()))?;
-            }
+        if let Some(block) = current_block
+            && block.get_terminator().is_none()
+        {
+            builder.build_return(Some(&i32_type.const_int(0, false)))
+                .map_err(|e| CodegenError::EmitFailed(e.to_string()))?;
         }
 
         Ok(())
@@ -638,7 +638,9 @@ impl<'ctx, 'prog> CodeGenerator<'ctx, 'prog> {
         let buf_val = self.resolve_pointer(&inputs[1].0, function, builder)?;
         let len_val = self.resolve_value(&inputs[2].0, function, builder)?;
 
-        let write_fn = self.functions["write"];
+        let write_fn = *self.functions.get("write").ok_or_else(|| {
+            CodegenError::UnresolvedNode("libc function 'write' not declared".to_string())
+        })?;
 
         // fd needs to be i32
         let fd_i32 = match fd_val {
@@ -687,7 +689,9 @@ impl<'ctx, 'prog> CodeGenerator<'ctx, 'prog> {
 
         let code_val = self.resolve_value(&inputs[0].0, function, builder)?;
 
-        let exit_fn = self.functions["_exit"];
+        let exit_fn = *self.functions.get("_exit").ok_or_else(|| {
+            CodegenError::UnresolvedNode("libc function '_exit' not declared".to_string())
+        })?;
 
         // code needs to be i32
         let code_i32 = match code_val {

--- a/flux-ftl/src/compiler.rs
+++ b/flux-ftl/src/compiler.rs
@@ -29,6 +29,8 @@ pub enum CompileError {
     IoError(io::Error),
     /// Invalid binary format.
     InvalidFormat(String),
+    /// A value exceeds the maximum representable size in the binary format.
+    Overflow(String),
 }
 
 impl fmt::Display for CompileError {
@@ -38,6 +40,7 @@ impl fmt::Display for CompileError {
             CompileError::SerializationError(msg) => write!(f, "serialization error: {}", msg),
             CompileError::IoError(e) => write!(f, "I/O error: {}", e),
             CompileError::InvalidFormat(msg) => write!(f, "invalid binary format: {}", msg),
+            CompileError::Overflow(msg) => write!(f, "overflow: {}", msg),
         }
     }
 }
@@ -550,24 +553,22 @@ pub fn compile(program: &Program) -> Result<CompiledGraph, CompileError> {
     let mut all_compiled: Vec<CompiledNode> = Vec::new();
     let mut seen_hashes: HashSet<[u8; 32]> = HashSet::new();
 
-    let reachable = collect_reachable(program);
-
     // Helper closure to build and dedup a node.
     let mut add_node = |id: &str, kind: NodeKind, data: Vec<u8>, ref_ids: &[String]| {
-        if let Some(&h) = hash_map.get(id) {
-            if seen_hashes.insert(h) {
-                let ref_hashes: Vec<[u8; 32]> = ref_ids
-                    .iter()
-                    .filter_map(|r| hash_map.get(r.as_str()).copied())
-                    .collect();
-                all_compiled.push(CompiledNode {
-                    hash: h,
-                    kind,
-                    original_id: id.to_string(),
-                    data,
-                    refs: ref_hashes,
-                });
-            }
+        if let Some(&h) = hash_map.get(id)
+            && seen_hashes.insert(h)
+        {
+            let ref_hashes: Vec<[u8; 32]> = ref_ids
+                .iter()
+                .filter_map(|r| hash_map.get(r.as_str()).copied())
+                .collect();
+            all_compiled.push(CompiledNode {
+                hash: h,
+                kind,
+                original_id: id.to_string(),
+                data,
+                refs: ref_hashes,
+            });
         }
     };
 
@@ -644,9 +645,10 @@ pub fn compile(program: &Program) -> Result<CompiledGraph, CompileError> {
 //
 // Format:
 //   Magic:       b"FLUX"   (4 bytes)
-//   Version:     1u32 LE   (4 bytes)
+//   Version:     2u32 LE   (4 bytes)
 //   Entry hash:  [u8; 32]
-//   Node count:  u32 LE
+//   Node count:  u32 LE    (unique nodes)
+//   Total nodes: u32 LE    (before deduplication)
 //   Per node:
 //     hash:      [u8; 32]
 //     kind:      u8
@@ -659,7 +661,7 @@ pub fn compile(program: &Program) -> Result<CompiledGraph, CompileError> {
 // ---------------------------------------------------------------------------
 
 const MAGIC: &[u8; 4] = b"FLUX";
-const VERSION: u32 = 1;
+const VERSION: u32 = 2;
 
 /// Write a compiled graph to a binary `.flux.bin` file.
 pub fn write_binary(graph: &CompiledGraph, path: &std::path::Path) -> Result<(), CompileError> {
@@ -672,8 +674,13 @@ pub fn write_binary(graph: &CompiledGraph, path: &std::path::Path) -> Result<(),
     // Entry hash
     file.write_all(&graph.entry_hash)?;
     // Node count
-    let count = graph.nodes.len() as u32;
+    let count = u32::try_from(graph.nodes.len())
+        .map_err(|_| CompileError::Overflow(format!("node count {} exceeds u32::MAX", graph.nodes.len())))?;
     file.write_all(&count.to_le_bytes())?;
+    // Total nodes (before deduplication)
+    let total_nodes = u32::try_from(graph.metadata.total_nodes)
+        .map_err(|_| CompileError::Overflow(format!("total_nodes {} exceeds u32::MAX", graph.metadata.total_nodes)))?;
+    file.write_all(&total_nodes.to_le_bytes())?;
 
     for node in &graph.nodes {
         // Hash
@@ -682,15 +689,18 @@ pub fn write_binary(graph: &CompiledGraph, path: &std::path::Path) -> Result<(),
         file.write_all(&[node.kind as u8])?;
         // ID
         let id_bytes = node.original_id.as_bytes();
-        let id_len = id_bytes.len() as u16;
+        let id_len = u16::try_from(id_bytes.len())
+            .map_err(|_| CompileError::Overflow(format!("node id length {} exceeds u16::MAX", id_bytes.len())))?;
         file.write_all(&id_len.to_le_bytes())?;
         file.write_all(id_bytes)?;
         // Data
-        let data_len = node.data.len() as u32;
+        let data_len = u32::try_from(node.data.len())
+            .map_err(|_| CompileError::Overflow(format!("node data length {} exceeds u32::MAX", node.data.len())))?;
         file.write_all(&data_len.to_le_bytes())?;
         file.write_all(&node.data)?;
         // Refs
-        let ref_count = node.refs.len() as u16;
+        let ref_count = u16::try_from(node.refs.len())
+            .map_err(|_| CompileError::Overflow(format!("ref count {} exceeds u16::MAX", node.refs.len())))?;
         file.write_all(&ref_count.to_le_bytes())?;
         for r in &node.refs {
             file.write_all(r)?;
@@ -743,6 +753,12 @@ pub fn read_binary(path: &std::path::Path) -> Result<CompiledGraph, CompileError
     let count_bytes = read_bytes(&mut pos, 4)?;
     let count = u32::from_le_bytes([
         count_bytes[0], count_bytes[1], count_bytes[2], count_bytes[3],
+    ]) as usize;
+
+    // Total nodes (before deduplication)
+    let total_bytes = read_bytes(&mut pos, 4)?;
+    let total_nodes = u32::from_le_bytes([
+        total_bytes[0], total_bytes[1], total_bytes[2], total_bytes[3],
     ]) as usize;
 
     let mut nodes = Vec::with_capacity(count);
@@ -801,7 +817,7 @@ pub fn read_binary(path: &std::path::Path) -> Result<CompiledGraph, CompileError
     Ok(CompiledGraph {
         entry_hash,
         metadata: GraphMetadata {
-            total_nodes: unique_nodes,
+            total_nodes,
             unique_nodes,
             entry_id,
         },

--- a/flux-ftl/src/main.rs
+++ b/flux-ftl/src/main.rs
@@ -25,6 +25,8 @@ struct FullResult {
     #[serde(skip_serializing_if = "Option::is_none")]
     compiled: Option<CompileMetadata>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    compile_error: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     feedback: Option<LlmFeedback>,
 }
 
@@ -68,6 +70,7 @@ fn main() {
                 validation_errors: Vec::new(),
                 proof_results: Vec::new(),
                 compiled: None,
+                compile_error: None,
                 feedback: Some(fb),
             };
             println!("{}", serde_json::to_string(&out).unwrap());
@@ -141,13 +144,13 @@ fn main() {
     };
 
     // Phase 5: Compilation (run unless fatal validation errors)
-    let compiled = if !has_fatal {
+    let (compiled, compile_error) = if !has_fatal {
         match compiler::compile(&ast) {
-            Ok(graph) => Some(CompileMetadata::from(&graph)),
-            Err(_) => None,
+            Ok(graph) => (Some(CompileMetadata::from(&graph)), None),
+            Err(e) => (None, Some(format!("{}", e))),
         }
     } else {
-        None
+        (None, None)
     };
 
     // Phase 7: Generate LLM feedback
@@ -175,6 +178,7 @@ fn main() {
         validation_errors,
         proof_results,
         compiled,
+        compile_error,
         feedback: Some(fb),
     };
 

--- a/flux-ftl/src/parser.rs
+++ b/flux-ftl/src/parser.rs
@@ -4,6 +4,9 @@ use pest_derive::Parser;
 use crate::ast::*;
 use crate::error::*;
 
+/// Parsed effect field data: (inputs, type_ref, effects, success, failure).
+type EffectFields = (Vec<NodeRef>, TypeRef, Vec<String>, Option<NodeRef>, Option<NodeRef>);
+
 #[derive(Parser)]
 #[grammar = "grammar.pest"]
 struct FtlParser;
@@ -32,36 +35,29 @@ fn parse_program(pairs: pest::iterators::Pairs<Rule>) -> Result<Program, ParseEr
     let mut entry = None;
 
     for pair in pairs {
-        match pair.as_rule() {
-            Rule::program => {
-                for inner in pair.into_inner() {
-                    match inner.as_rule() {
-                        Rule::statement => {
-                            let stmt = inner.into_inner().next().unwrap();
-                            match stmt.as_rule() {
-                                Rule::type_def => types.push(parse_type_def(stmt)?),
-                                Rule::region_def => regions.push(parse_region_def(stmt)?),
-                                Rule::compute_def => computes.push(parse_compute_def(stmt)?),
-                                Rule::effect_def => effects.push(parse_effect_def(stmt)?),
-                                Rule::control_def => controls.push(parse_control_def(stmt)?),
-                                Rule::contract_def => {
-                                    contracts.push(parse_contract_def(stmt)?);
-                                }
-                                Rule::memory_def => memories.push(parse_memory_def(stmt)?),
-                                Rule::extern_def => externs.push(parse_extern_def(stmt)?),
-                                Rule::entry_def => {
-                                    let node = stmt.into_inner().next().unwrap();
-                                    entry = Some(NodeRef::new(node.as_str()));
-                                }
-                                _ => {}
-                            }
+        if pair.as_rule() == Rule::program {
+            for inner in pair.into_inner() {
+                if inner.as_rule() == Rule::statement {
+                    let stmt = inner.into_inner().next().unwrap();
+                    match stmt.as_rule() {
+                        Rule::type_def => types.push(parse_type_def(stmt)?),
+                        Rule::region_def => regions.push(parse_region_def(stmt)?),
+                        Rule::compute_def => computes.push(parse_compute_def(stmt)?),
+                        Rule::effect_def => effects.push(parse_effect_def(stmt)?),
+                        Rule::control_def => controls.push(parse_control_def(stmt)?),
+                        Rule::contract_def => {
+                            contracts.push(parse_contract_def(stmt)?);
                         }
-                        Rule::EOI => {}
+                        Rule::memory_def => memories.push(parse_memory_def(stmt)?),
+                        Rule::extern_def => externs.push(parse_extern_def(stmt)?),
+                        Rule::entry_def => {
+                            let node = stmt.into_inner().next().unwrap();
+                            entry = Some(NodeRef::new(node.as_str()));
+                        }
                         _ => {}
                     }
                 }
             }
-            _ => {}
         }
     }
 
@@ -600,7 +596,7 @@ fn parse_effect_body(pair: pest::iterators::Pair<Rule>) -> Result<EffectOp, Pars
 
 fn parse_effect_field_pairs(
     pair: pest::iterators::Pair<Rule>,
-) -> Result<(Vec<NodeRef>, TypeRef, Vec<String>, Option<NodeRef>, Option<NodeRef>), ParseError> {
+) -> Result<EffectFields, ParseError> {
     let mut inputs = Vec::new();
     let mut type_ref = TypeRef::Builtin {
         name: "unit".to_string(),
@@ -1058,38 +1054,30 @@ fn parse_field_access_parts(parts: Vec<pest::iterators::Pair<Rule>>) -> (NodeRef
 // ---------------------------------------------------------------------------
 
 fn parse_formula_additive_as_expr(pair: pest::iterators::Pair<Rule>) -> Result<Expr, ParseError> {
-    let mut parts: Vec<pest::iterators::Pair<Rule>> = pair.into_inner().collect();
+    let parts: Vec<pest::iterators::Pair<Rule>> = pair.into_inner().collect();
     if parts.len() == 1 {
-        return parse_formula_multiplicative_as_expr(parts.remove(0));
+        return parse_formula_multiplicative_as_expr(parts.into_iter().next().unwrap());
     }
     // Alternating: multiplicative, op, multiplicative, op, multiplicative, ...
-    let mut result = parse_formula_multiplicative_as_expr(parts.remove(0))?;
-    let mut i = 0;
-    while i < parts.len() {
-        let op = match parts[i].as_str() {
+    let mut iter = parts.into_iter();
+    let mut result = parse_formula_multiplicative_as_expr(iter.next().unwrap())?;
+
+    while let Some(op_pair) = iter.next() {
+        let op = match op_pair.as_str() {
             "+" => ArithBinOp::Add,
             "-" => ArithBinOp::Sub,
             _ => ArithBinOp::Add,
         };
-        i += 1;
-        if i < parts.len() {
-            let right = parse_formula_multiplicative_as_expr(parts.remove(i))?;
-            // Remove the op too (it's now at position i-1... but we already moved past it)
-            // Actually, let me redo this with a proper loop
+        if let Some(rhs_pair) = iter.next() {
+            let right = parse_formula_multiplicative_as_expr(rhs_pair)?;
             result = Expr::BinOp {
                 left: Box::new(result),
                 op,
                 right: Box::new(right),
             };
         }
-        // After removing one element, adjust
-        break; // This approach is broken, let me redo
     }
 
-    // Better approach: collect into vec, process in pairs
-    // Already started with result from first element. Let me re-parse.
-    // Actually the issue is I already removed the first element.
-    // Let me restart with a different approach.
     Ok(result)
 }
 

--- a/flux-ftl/src/prover.rs
+++ b/flux-ftl/src/prover.rs
@@ -218,8 +218,7 @@ fn collect_type_constraints<'z>(
         }
 
         // Case 2: "state.length" or "state.score" — resolve via loop state_type
-        if sym_name.starts_with("state.") {
-            let field_name = &sym_name["state.".len()..];
+        if let Some(field_name) = sym_name.strip_prefix("state.") {
             // Find the contract's target and look for a loop with state_type
             if let Some(state_type_ref) = find_loop_state_type(prover_ctx, contract)
                 && let Some(type_body) = resolve_type(prover_ctx, state_type_ref)
@@ -241,10 +240,10 @@ fn find_loop_state_type<'a>(
 ) -> Option<&'a TypeRef> {
     let target = contract.target.as_str();
     // Direct target is a K-Node loop
-    if let Some(kdef) = prover_ctx.controls.get(target) {
-        if let ControlOp::Loop { state_type, .. } = &kdef.op {
-            return Some(state_type);
-        }
+    if let Some(kdef) = prover_ctx.controls.get(target)
+        && let ControlOp::Loop { state_type, .. } = &kdef.op
+    {
+        return Some(state_type);
     }
     None
 }
@@ -312,13 +311,13 @@ fn add_struct_field_constraints<'z>(
         // in the same struct and constrain by max_length.
         if field_name == "length" || field_name == "len" {
             for sf in fields {
-                if let Some(type_body) = resolve_type(prover_ctx, &sf.type_ref) {
-                    if let TypeBody::Array { max_length, .. } = type_body {
-                        let z3_var = Int::new_const(z3_ctx, var_name);
-                        constraints.push(z3_var.ge(&Int::from_i64(z3_ctx, 0)));
-                        constraints.push(z3_var.le(&Int::from_i64(z3_ctx, *max_length as i64)));
-                        break;
-                    }
+                if let Some(type_body) = resolve_type(prover_ctx, &sf.type_ref)
+                    && let TypeBody::Array { max_length, .. } = type_body
+                {
+                    let z3_var = Int::new_const(z3_ctx, var_name);
+                    constraints.push(z3_var.ge(&Int::from_i64(z3_ctx, 0)));
+                    constraints.push(z3_var.le(&Int::from_i64(z3_ctx, *max_length as i64)));
+                    break;
                 }
             }
         }
@@ -337,10 +336,10 @@ fn collect_assume_axioms<'z>(
 ) -> Vec<Bool<'z>> {
     let mut axioms = Vec::new();
     for clause in &clauses[..current_idx] {
-        if let ContractClause::Assume { formula } = clause {
-            if let Some(z3_f) = translate_formula(z3_ctx, prover_ctx, formula) {
-                axioms.push(z3_f);
-            }
+        if let ContractClause::Assume { formula } = clause
+            && let Some(z3_f) = translate_formula(z3_ctx, prover_ctx, formula)
+        {
+            axioms.push(z3_f);
         }
     }
     axioms
@@ -531,11 +530,8 @@ fn prove_clause<'z>(
     type_constraints: &[Bool<'z>],
     config: &ProverConfig,
 ) -> (ProofStatus, Option<String>) {
-    match clause {
-        ContractClause::Assume { .. } => {
-            return (ProofStatus::Assumed, None);
-        }
-        _ => {}
+    if let ContractClause::Assume { .. } = clause {
+        return (ProofStatus::Assumed, None);
     }
 
     let formula = match clause {

--- a/flux-ftl/src/region_checker.rs
+++ b/flux-ftl/src/region_checker.rs
@@ -96,12 +96,11 @@ fn build_region_index(program: &Program) -> HashMap<String, RegionInfo> {
                         }
                     }
                     Lifetime::Scoped => {
-                        if let Some(ref parent_id) = info.parent {
-                            if let Some(parent_info) = index.get(parent_id) {
-                                if let Some(parent_depth) = parent_info.depth {
-                                    return Some((id.clone(), parent_depth + 1));
-                                }
-                            }
+                        if let Some(ref parent_id) = info.parent
+                            && let Some(parent_info) = index.get(parent_id)
+                            && let Some(parent_depth) = parent_info.depth
+                        {
+                            return Some((id.clone(), parent_depth + 1));
                         }
                         // Scoped without parent (6004) or parent not yet resolved
                         // — cannot compute depth.
@@ -161,19 +160,19 @@ fn check_region_hierarchy(index: &HashMap<String, RegionInfo>, errors: &mut Vec<
         }
 
         // 6001: parent references a non-existent region.
-        if let Some(ref parent_id) = info.parent {
-            if !index.contains_key(parent_id) {
-                errors.push(RegionError {
-                    error_code: 6001,
-                    node_id: id.clone(),
-                    violation: "REGION_PARENT_NOT_FOUND".into(),
-                    message: format!(
-                        "Region {} references non-existent parent {}",
-                        id, parent_id
-                    ),
-                    suggestion: Some(format!("Define {} or fix the parent reference", parent_id)),
-                });
-            }
+        if let Some(ref parent_id) = info.parent
+            && !index.contains_key(parent_id)
+        {
+            errors.push(RegionError {
+                error_code: 6001,
+                node_id: id.clone(),
+                violation: "REGION_PARENT_NOT_FOUND".into(),
+                message: format!(
+                    "Region {} references non-existent parent {}",
+                    id, parent_id
+                ),
+                suggestion: Some(format!("Define {} or fix the parent reference", parent_id)),
+            });
         }
     }
 
@@ -319,27 +318,24 @@ fn check_region_escapes(
             let value_region = resolve_region(value.as_str());
 
             // Only check when both regions are known.
-            if let (Some(tr), Some(vr)) = (target_region, value_region) {
-                if let (Some(target_depth), Some(value_depth)) = (depth_of(tr), depth_of(vr)) {
-                    // If the value lives in a shorter-lived (deeper) region than
-                    // the target, data would escape when the value's region ends.
-                    if value_depth > target_depth {
-                        errors.push(RegionError {
-                            error_code: 6006,
-                            node_id: m.id.as_str().to_owned(),
-                            violation: "REGION_ESCAPE".into(),
-                            message: format!(
-                                "Store {} writes a value from region {} (depth {}) \
-                                 into target in region {} (depth {}) — \
-                                 data would escape the shorter-lived region",
-                                m.id, vr, value_depth, tr, target_depth
-                            ),
-                            suggestion: Some(
-                                "Move the value to the same or a longer-lived region".into(),
-                            ),
-                        });
-                    }
-                }
+            if let (Some(tr), Some(vr)) = (target_region, value_region)
+                && let (Some(target_depth), Some(value_depth)) = (depth_of(tr), depth_of(vr))
+                && value_depth > target_depth
+            {
+                errors.push(RegionError {
+                    error_code: 6006,
+                    node_id: m.id.as_str().to_owned(),
+                    violation: "REGION_ESCAPE".into(),
+                    message: format!(
+                        "Store {} writes a value from region {} (depth {}) \
+                         into target in region {} (depth {}) — \
+                         data would escape the shorter-lived region",
+                        m.id, vr, value_depth, tr, target_depth
+                    ),
+                    suggestion: Some(
+                        "Move the value to the same or a longer-lived region".into(),
+                    ),
+                });
             }
         }
     }

--- a/flux-ftl/src/type_checker.rs
+++ b/flux-ftl/src/type_checker.rs
@@ -266,23 +266,23 @@ fn check_compute_types(
                 if is_comparison_op {
                     // Comparison ops: output must be Boolean, inputs must be
                     // compatible with each other (but NOT with the output type).
-                    if let Some(body) = resolve_type(type_ref, type_index) {
-                        if !matches!(body, TypeBody::Boolean) {
-                            errors.push(CheckError {
-                                error_code: 3001,
-                                node_id: node_id.clone(),
-                                violation: "TYPE_MISMATCH".into(),
-                                message: format!(
-                                    "Comparison op '{}' must return Boolean, but got {}",
-                                    opcode,
-                                    type_ref_label(type_ref, type_index),
-                                ),
-                                suggestion: Some(format!(
-                                    "Change the output type of {} to Boolean",
-                                    node_id,
-                                )),
-                            });
-                        }
+                    if let Some(body) = resolve_type(type_ref, type_index)
+                        && !matches!(body, TypeBody::Boolean)
+                    {
+                        errors.push(CheckError {
+                            error_code: 3001,
+                            node_id: node_id.clone(),
+                            violation: "TYPE_MISMATCH".into(),
+                            message: format!(
+                                "Comparison op '{}' must return Boolean, but got {}",
+                                opcode,
+                                type_ref_label(type_ref, type_index),
+                            ),
+                            suggestion: Some(format!(
+                                "Change the output type of {} to Boolean",
+                                node_id,
+                            )),
+                        });
                     }
                     // Check inputs are compatible with each other
                     let input_types: Vec<_> = inputs.iter()
@@ -321,32 +321,32 @@ fn check_compute_types(
                 } else {
                     // Non-comparison arith ops: check inputs match output type
                     for input in inputs {
-                        if let Some(input_tr) = compute_type_map.get(input.as_str()) {
-                            if !types_match(input_tr, type_ref) {
-                                // Allow compatible integer types (different widths)
-                                let compatible = matches!(
-                                    (resolve_type(input_tr, type_index), resolve_type(type_ref, type_index)),
-                                    (Some(a), Some(b)) if is_integer_type(a) && is_integer_type(b)
-                                );
-                                if !compatible {
-                                    errors.push(CheckError {
-                                        error_code: 3001,
-                                        node_id: node_id.clone(),
-                                        violation: "TYPE_MISMATCH".into(),
-                                        message: format!(
-                                            "Arith op '{}' expects all inputs of type {}, but input {} has type {}",
-                                            opcode,
-                                            type_ref_label(type_ref, type_index),
-                                            input,
-                                            type_ref_label(input_tr, type_index),
-                                        ),
-                                        suggestion: Some(format!(
-                                            "Ensure all inputs to {} have type {}",
-                                            node_id,
-                                            type_ref_label(type_ref, type_index),
-                                        )),
-                                    });
-                                }
+                        if let Some(input_tr) = compute_type_map.get(input.as_str())
+                            && !types_match(input_tr, type_ref)
+                        {
+                            // Allow compatible integer types (different widths)
+                            let compatible = matches!(
+                                (resolve_type(input_tr, type_index), resolve_type(type_ref, type_index)),
+                                (Some(a), Some(b)) if is_integer_type(a) && is_integer_type(b)
+                            );
+                            if !compatible {
+                                errors.push(CheckError {
+                                    error_code: 3001,
+                                    node_id: node_id.clone(),
+                                    violation: "TYPE_MISMATCH".into(),
+                                    message: format!(
+                                        "Arith op '{}' expects all inputs of type {}, but input {} has type {}",
+                                        opcode,
+                                        type_ref_label(type_ref, type_index),
+                                        input,
+                                        type_ref_label(input_tr, type_index),
+                                    ),
+                                    suggestion: Some(format!(
+                                        "Ensure all inputs to {} have type {}",
+                                        node_id,
+                                        type_ref_label(type_ref, type_index),
+                                    )),
+                                });
                             }
                         }
                     }
@@ -399,8 +399,8 @@ fn check_compute_types(
                     } else {
                         // Check each param type
                         for (i, (input, param_tr)) in inputs.iter().zip(params.iter()).enumerate() {
-                            if let Some(input_tr) = compute_type_map.get(input.as_str()) {
-                                if !types_match(input_tr, param_tr) {
+                            if let Some(input_tr) = compute_type_map.get(input.as_str())
+                                && !types_match(input_tr, param_tr) {
                                     errors.push(CheckError {
                                         error_code: 3005,
                                         node_id: node_id.clone(),
@@ -416,7 +416,6 @@ fn check_compute_types(
                                         suggestion: None,
                                     });
                                 }
-                            }
                         }
                     }
                     // Check result type matches declared type_ref
@@ -466,8 +465,8 @@ fn check_compute_types(
                 }
                 if name == "variant_tag" {
                     // variant_tag should produce an integer
-                    if let Some(body) = resolve_type(type_ref, type_index) {
-                        if !is_integer_type(body) {
+                    if let Some(body) = resolve_type(type_ref, type_index)
+                        && !is_integer_type(body) {
                             errors.push(CheckError {
                                 error_code: 3001,
                                 node_id: node_id.clone(),
@@ -480,7 +479,6 @@ fn check_compute_types(
                                 suggestion: Some("variant_tag result type should be an integer (e.g. u16)".into()),
                             });
                         }
-                    }
                 }
             }
 
@@ -506,10 +504,10 @@ fn check_struct_field_access(
     // The field name is typically encoded in the second input as a const string,
     // but since we don't have a direct way to extract it from the graph at this
     // level, we do a best-effort check: verify the first input is a struct type.
-    if let Some(first_input) = inputs.first() {
-        if let Some(input_tr) = compute_type_map.get(first_input.as_str()) {
-            if let Some(body) = resolve_type(input_tr, type_index) {
-                if !matches!(body, TypeBody::Struct { .. }) {
+    if let Some(first_input) = inputs.first()
+        && let Some(input_tr) = compute_type_map.get(first_input.as_str())
+            && let Some(body) = resolve_type(input_tr, type_index)
+                && !matches!(body, TypeBody::Struct { .. }) {
                     errors.push(CheckError {
                         error_code: 3002,
                         node_id: node_id.to_string(),
@@ -527,9 +525,6 @@ fn check_struct_field_access(
                         )),
                     });
                 }
-            }
-        }
-    }
 }
 
 /// Check that array index input is an integer type.
@@ -545,9 +540,9 @@ fn check_array_index(
     // The index (second input) must be integer.
     if inputs.len() >= 2 {
         let index_ref = &inputs[1];
-        if let Some(index_tr) = compute_type_map.get(index_ref.as_str()) {
-            if let Some(body) = resolve_type(index_tr, type_index) {
-                if !is_integer_type(body) {
+        if let Some(index_tr) = compute_type_map.get(index_ref.as_str())
+            && let Some(body) = resolve_type(index_tr, type_index)
+                && !is_integer_type(body) {
                     errors.push(CheckError {
                         error_code: 3004,
                         node_id: node_id.to_string(),
@@ -565,8 +560,6 @@ fn check_array_index(
                         )),
                     });
                 }
-            }
-        }
     }
 }
 
@@ -633,8 +626,8 @@ fn check_effect_nodes(program: &Program, errors: &mut Vec<CheckError>) {
                     }
 
                     // 4002: check that success/failure targets exist
-                    if let Some(s) = success {
-                        if !all_ids.contains(s.as_str()) {
+                    if let Some(s) = success
+                        && !all_ids.contains(s.as_str()) {
                             errors.push(CheckError {
                                 error_code: 4002,
                                 node_id: node_id.clone(),
@@ -649,9 +642,8 @@ fn check_effect_nodes(program: &Program, errors: &mut Vec<CheckError>) {
                                 )),
                             });
                         }
-                    }
-                    if let Some(f) = failure {
-                        if !all_ids.contains(f.as_str()) {
+                    if let Some(f) = failure
+                        && !all_ids.contains(f.as_str()) {
                             errors.push(CheckError {
                                 error_code: 4002,
                                 node_id: node_id.clone(),
@@ -666,7 +658,6 @@ fn check_effect_nodes(program: &Program, errors: &mut Vec<CheckError>) {
                                 )),
                             });
                         }
-                    }
                 }
 
                 // 4003: empty effects list (warning)
@@ -776,8 +767,8 @@ fn check_effect_nodes(program: &Program, errors: &mut Vec<CheckError>) {
                 }
 
                 // 4002: reachability
-                if let Some(s) = success {
-                    if !all_ids.contains(s.as_str()) {
+                if let Some(s) = success
+                    && !all_ids.contains(s.as_str()) {
                         errors.push(CheckError {
                             error_code: 4002,
                             node_id: node_id.clone(),
@@ -789,9 +780,8 @@ fn check_effect_nodes(program: &Program, errors: &mut Vec<CheckError>) {
                             suggestion: Some(format!("Define node {} or update the success path of {}", s, node_id)),
                         });
                     }
-                }
-                if let Some(f) = failure {
-                    if !all_ids.contains(f.as_str()) {
+                if let Some(f) = failure
+                    && !all_ids.contains(f.as_str()) {
                         errors.push(CheckError {
                             error_code: 4002,
                             node_id: node_id.clone(),
@@ -803,7 +793,6 @@ fn check_effect_nodes(program: &Program, errors: &mut Vec<CheckError>) {
                             suggestion: Some(format!("Define node {} or update the failure path of {}", f, node_id)),
                         });
                     }
-                }
 
                 // 4003: empty effects
                 if effects.is_empty() {
@@ -858,9 +847,9 @@ fn check_control_nodes(
                 }
 
                 // condition should be boolean-typed
-                if let Some(cond_tr) = compute_type_map.get(condition.as_str()) {
-                    if let Some(body) = resolve_type(cond_tr, type_index) {
-                        if !matches!(body, TypeBody::Boolean) {
+                if let Some(cond_tr) = compute_type_map.get(condition.as_str())
+                    && let Some(body) = resolve_type(cond_tr, type_index)
+                        && !matches!(body, TypeBody::Boolean) {
                             errors.push(CheckError {
                                 error_code: 3001,
                                 node_id: node_id.clone(),
@@ -874,21 +863,19 @@ fn check_control_nodes(
                                 suggestion: Some("Loop conditions must evaluate to a boolean".into()),
                             });
                         }
-                    }
-                }
             }
 
             // K:Branch — condition should be boolean; check exhaustiveness for variant
             ControlOp::Branch { condition, .. } => {
-                if let Some(cond_tr) = compute_type_map.get(condition.as_str()) {
-                    if let Some(body) = resolve_type(cond_tr, type_index) {
+                if let Some(cond_tr) = compute_type_map.get(condition.as_str())
+                    && let Some(body) = resolve_type(cond_tr, type_index) {
                         // If condition is a variant_tag result, we'd need to check
                         // exhaustiveness — but a simple Branch only has true/false,
                         // so variant exhaustiveness applies to multi-way branches.
                         // For a binary branch on boolean, this is fine.
                         // For a binary branch on a variant with >2 cases, it's non-exhaustive.
-                        if let TypeBody::Variant { cases } = body {
-                            if cases.len() > 2 {
+                        if let TypeBody::Variant { cases } = body
+                            && cases.len() > 2 {
                                 errors.push(CheckError {
                                     error_code: 3003,
                                     node_id: node_id.clone(),
@@ -904,9 +891,7 @@ fn check_control_nodes(
                                     )),
                                 });
                             }
-                        }
                     }
-                }
             }
 
             // K:Par — check branch count
@@ -955,7 +940,7 @@ fn check_memory_types(
                 if let Some(alloc_tr) = alloc_type_map.get(source.as_str()) {
                     let direct_match = types_match(alloc_tr, type_ref);
                     let element_match = match resolve_type(alloc_tr, type_index) {
-                        Some(TypeBody::Array { element, .. }) => types_match(&element, type_ref),
+                        Some(TypeBody::Array { element, .. }) => types_match(element, type_ref),
                         Some(TypeBody::Struct { .. }) => true, // struct field access
                         _ => false,
                     };
@@ -979,9 +964,9 @@ fn check_memory_types(
                     }
                 }
                 // Check that index is integer-typed
-                if let Some(index_tr) = compute_type_map.get(index.as_str()) {
-                    if let Some(body) = resolve_type(index_tr, type_index) {
-                        if !is_integer_type(body) {
+                if let Some(index_tr) = compute_type_map.get(index.as_str())
+                    && let Some(body) = resolve_type(index_tr, type_index)
+                        && !is_integer_type(body) {
                             errors.push(CheckError {
                                 error_code: 3004,
                                 node_id: node_id.clone(),
@@ -998,18 +983,16 @@ fn check_memory_types(
                                 )),
                             });
                         }
-                    }
-                }
             }
 
             MemoryOp::Store { target, value, index, .. } => {
                 // Check that stored value type matches the alloc type or its element type
-                if let Some(alloc_tr) = alloc_type_map.get(target.as_str()) {
-                    if let Some(value_tr) = compute_type_map.get(value.as_str()) {
+                if let Some(alloc_tr) = alloc_type_map.get(target.as_str())
+                    && let Some(value_tr) = compute_type_map.get(value.as_str()) {
                         let direct_match = types_match(value_tr, alloc_tr);
                         let element_match = match resolve_type(alloc_tr, type_index) {
                             Some(TypeBody::Array { element, .. }) => {
-                                types_match(value_tr, &element)
+                                types_match(value_tr, element)
                                 || is_zero_literal(value.as_str(), program)
                             }
                             Some(TypeBody::Struct { .. }) => true, // struct field write
@@ -1035,11 +1018,10 @@ fn check_memory_types(
                             });
                         }
                     }
-                }
                 // Check that index is integer-typed
-                if let Some(index_tr) = compute_type_map.get(index.as_str()) {
-                    if let Some(body) = resolve_type(index_tr, type_index) {
-                        if !is_integer_type(body) {
+                if let Some(index_tr) = compute_type_map.get(index.as_str())
+                    && let Some(body) = resolve_type(index_tr, type_index)
+                        && !is_integer_type(body) {
                             errors.push(CheckError {
                                 error_code: 3004,
                                 node_id: node_id.clone(),
@@ -1056,8 +1038,6 @@ fn check_memory_types(
                                 )),
                             });
                         }
-                    }
-                }
             }
 
             MemoryOp::Alloc { .. } => {}
@@ -1110,8 +1090,8 @@ fn check_extern_types(
                 } else {
                     // Check each parameter type
                     for (i, (input, param_tr)) in inputs.iter().zip(ext.params.iter()).enumerate() {
-                        if let Some(input_tr) = compute_type_map.get(input.as_str()) {
-                            if !types_match(input_tr, param_tr) {
+                        if let Some(input_tr) = compute_type_map.get(input.as_str())
+                            && !types_match(input_tr, param_tr) {
                                 // In FFI context, arrays implicitly decay to pointers.
                                 // An array type is compatible with an integer type that
                                 // represents a pointer (the array's base address).
@@ -1138,7 +1118,6 @@ fn check_extern_types(
                                     });
                                 }
                             }
-                        }
                     }
                 }
 

--- a/flux-ftl/src/validator.rs
+++ b/flux-ftl/src/validator.rs
@@ -74,19 +74,24 @@ fn build_index(program: &Program, errors: &mut Vec<ValidationError>) -> HashMap<
 
     let mut insert = |id: &NodeRef, kind: NodeKind, errors: &mut Vec<ValidationError>| {
         let key = id.as_str().to_string();
-        if index.contains_key(&key) {
-            errors.push(ValidationError {
-                error_code: 1001,
-                node_id: key.clone(),
-                violation: "DUPLICATE_ID".to_string(),
-                message: format!("Node {} is defined more than once", key),
-                suggestion: Some(format!(
-                    "Rename one of the duplicate {} definitions to a unique ID",
-                    key
-                )),
-            });
-        } else {
-            index.insert(key, kind);
+        use std::collections::hash_map::Entry;
+        match index.entry(key) {
+            Entry::Occupied(e) => {
+                let key = e.key().clone();
+                errors.push(ValidationError {
+                    error_code: 1001,
+                    node_id: key.clone(),
+                    violation: "DUPLICATE_ID".to_string(),
+                    message: format!("Node {} is defined more than once", key),
+                    suggestion: Some(format!(
+                        "Rename one of the duplicate {} definitions to a unique ID",
+                        key
+                    )),
+                });
+            }
+            Entry::Vacant(e) => {
+                e.insert(kind);
+            }
         }
     };
 


### PR DESCRIPTION
## Summary
- codegen.rs: HashMap `.get()` statt direkte Indexierung
- compiler.rs: Doppelte reachability eliminiert, Overflow-Guards, Binary-Format v2 mit total_nodes
- main.rs: Compilation-Errors nicht mehr silent geswallowed
- parser.rs: `never_loop` Bug gefixt
- Alle Clippy-Warnings in prover, compiler, region_checker, type_checker, validator behoben
- `cargo clippy -- -D warnings` → 0 errors, 0 warnings

## Test plan
- [x] 179 Tests bestanden
- [x] `cargo clippy -- -D warnings` exit code 0

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)