### PR TITLE
Phase 14: CLI-Integration — generate + evolve Subcommands

### DIFF
--- a/flux-ftl/src/main.rs
+++ b/flux-ftl/src/main.rs
@@ -9,6 +9,7 @@ use flux_ftl::compiler::{self, CompileMetadata};
 use flux_ftl::error::Status;
 use flux_ftl::evolution::{self, EvolutionConfig, GraphPool};
 use flux_ftl::feedback::{self, LlmFeedback, ValidationError as FeedbackValidationError};
+use flux_ftl::llm::{GenerateRequest, GenerationLoop, LlmConfig, LlmProvider, RequirementType};
 use flux_ftl::optimizer::{self, OptimizationConfig};
 use flux_ftl::parser::parse_ftl;
 use flux_ftl::prover::{prove_contracts, ProofResult, ProofStatus, ProverConfig};
@@ -53,6 +54,31 @@ enum Commands {
     /// Emit LLVM IR for debugging
     Ir {
         file: String,
+    },
+    /// Generate FTL from natural language using LLM
+    Generate {
+        /// Natural language requirement
+        requirement: String,
+
+        /// Requirement type: translate, optimize, invent, discover
+        #[arg(long, default_value = "translate")]
+        requirement_type: String,
+
+        /// LLM provider: anthropic, openai
+        #[arg(long, default_value = "anthropic")]
+        provider: String,
+
+        /// Model name (default depends on provider)
+        #[arg(long)]
+        model: Option<String>,
+
+        /// Max repair iterations
+        #[arg(long, default_value = "5")]
+        max_iterations: u32,
+
+        /// Output file for generated FTL (stdout if not set)
+        #[arg(short, long)]
+        output: Option<String>,
     },
     /// Evolve graph variants using a genetic algorithm
     Evolve {
@@ -574,6 +600,108 @@ fn cmd_ir(file: &str) -> ExitCode {
 }
 
 // ---------------------------------------------------------------------------
+// Generate subcommand
+// ---------------------------------------------------------------------------
+
+fn cmd_generate(
+    requirement: &str,
+    requirement_type: &str,
+    provider: &str,
+    model: Option<&str>,
+    max_iterations: u32,
+    output: Option<&str>,
+) -> ExitCode {
+    // Parse requirement type
+    let req_type = match RequirementType::from_str_loose(requirement_type) {
+        Ok(t) => t,
+        Err(e) => {
+            eprintln!("error: {}", e);
+            return ExitCode::from(2);
+        }
+    };
+
+    // Parse provider
+    let llm_provider = match LlmProvider::from_str_loose(provider) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("error: {}", e);
+            return ExitCode::from(2);
+        }
+    };
+
+    // Build config from environment
+    let mut config = match LlmConfig::from_env(llm_provider, model.map(String::from)) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("error: {}", e);
+            return ExitCode::from(1);
+        }
+    };
+    config.max_iterations = max_iterations;
+
+    // Create generation loop
+    let gen_loop = match GenerationLoop::new(config) {
+        Ok(l) => l,
+        Err(e) => {
+            eprintln!("error: {}", e);
+            return ExitCode::from(2);
+        }
+    };
+
+    let request = GenerateRequest {
+        requirement: requirement.to_string(),
+        requirement_type: req_type,
+        context: None,
+        examples: Vec::new(),
+    };
+
+    // Run async generation loop
+    let rt = match tokio::runtime::Runtime::new() {
+        Ok(rt) => rt,
+        Err(e) => {
+            eprintln!("error: failed to create async runtime: {}", e);
+            return ExitCode::from(2);
+        }
+    };
+
+    let result = match rt.block_on(gen_loop.generate(&request)) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("error: generation failed: {}", e);
+            return ExitCode::from(1);
+        }
+    };
+
+    // Serialize result as JSON
+    let json = match serde_json::to_string_pretty(&result) {
+        Ok(j) => j,
+        Err(e) => {
+            eprintln!("error: JSON serialization: {}", e);
+            return ExitCode::from(2);
+        }
+    };
+
+    // Output to file or stdout
+    if let Some(path) = output {
+        if let Err(e) = std::fs::write(path, &json) {
+            eprintln!("error: write output file: {}", e);
+            return ExitCode::from(2);
+        }
+        eprintln!("Output written to {}", path);
+    } else {
+        println!("{}", json);
+    }
+
+    let exit_code = match result.final_status {
+        flux_ftl::llm::GenerationStatus::Success
+        | flux_ftl::llm::GenerationStatus::PartialSuccess => 0,
+        _ => 1,
+    };
+
+    ExitCode::from(exit_code)
+}
+
+// ---------------------------------------------------------------------------
 // Evolve subcommand
 // ---------------------------------------------------------------------------
 
@@ -686,6 +814,21 @@ fn main() -> ExitCode {
             opt_level,
         }) => cmd_build(file, output.as_deref(), opt_level),
         Some(Commands::Ir { ref file }) => cmd_ir(file),
+        Some(Commands::Generate {
+            ref requirement,
+            ref requirement_type,
+            ref provider,
+            ref model,
+            max_iterations,
+            ref output,
+        }) => cmd_generate(
+            requirement,
+            requirement_type,
+            provider,
+            model.as_deref(),
+            max_iterations,
+            output.as_deref(),
+        ),
         Some(Commands::Evolve {
             ref file,
             generations,

--- a/flux-ftl/tests/cli_tests.rs
+++ b/flux-ftl/tests/cli_tests.rs
@@ -165,3 +165,103 @@ fn check_text_format() {
         "text output should contain 'Prove'"
     );
 }
+
+#[test]
+fn test_generate_help() {
+    let output = flux_cmd()
+        .args(["generate", "--help"])
+        .output()
+        .expect("failed to execute");
+
+    assert!(output.status.success(), "generate --help should succeed");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("--requirement-type"),
+        "help should mention --requirement-type"
+    );
+    assert!(
+        stdout.contains("--provider"),
+        "help should mention --provider"
+    );
+    assert!(
+        stdout.contains("--model"),
+        "help should mention --model"
+    );
+    assert!(
+        stdout.contains("--max-iterations"),
+        "help should mention --max-iterations"
+    );
+    assert!(
+        stdout.contains("--output"),
+        "help should mention --output"
+    );
+}
+
+#[test]
+fn test_generate_missing_api_key() {
+    // Run without any API key env vars set — should produce a clear error, not panic
+    let output = flux_cmd()
+        .args(["generate", "Write a hello world program"])
+        .env_remove("ANTHROPIC_API_KEY")
+        .env_remove("OPENAI_API_KEY")
+        .output()
+        .expect("failed to execute");
+
+    assert!(
+        !output.status.success(),
+        "should fail without API key"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("API key") || stderr.contains("ANTHROPIC_API_KEY"),
+        "error message should mention API key, got: {}",
+        stderr
+    );
+}
+
+#[test]
+fn test_evolve_with_testdata() {
+    let output = flux_cmd()
+        .args([
+            "evolve",
+            "testdata/hello_world.ftl",
+            "--generations",
+            "2",
+            "--population",
+            "5",
+            "--seed",
+            "42",
+        ])
+        .output()
+        .expect("failed to execute");
+
+    assert!(
+        output.status.success(),
+        "evolve failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // stdout should be valid JSON (the best evolved program)
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value =
+        serde_json::from_str(&stdout).expect("evolve stdout is not valid JSON");
+
+    // Should contain nodes and entry (the program structure)
+    assert!(
+        json["nodes"].is_array() || json["entry"].is_string(),
+        "JSON output should contain program structure"
+    );
+
+    // stderr should contain evolution stats
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Evolution complete"),
+        "stderr should contain evolution summary"
+    );
+    assert!(
+        stderr.contains("best fitness"),
+        "stderr should contain best fitness"
+    );
+}


### PR DESCRIPTION
## Summary
- `generate` Subcommand vollständig in main.rs integriert (async tokio runtime)
- `evolve` Subcommand verifiziert und funktionsfähig
- Graceful Error-Handling bei fehlenden API-Keys (kein Panic)
- 3 neue CLI-Tests

## Test plan
- [x] `cargo test` — 296 Tests bestanden
- [x] `cargo clippy -- -D warnings` — clean
- [x] `test_generate_help` — Help-Output korrekt
- [x] `test_generate_missing_api_key` — Sinnvolle Fehlermeldung
- [x] `test_evolve_with_testdata` — JSON-Output mit seed=42

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)